### PR TITLE
(server) fix:양방향 참조 객체 무한루프 해결

### DIFF
--- a/my-diary-back/my-diary-back/src/main/java/kr/ac/kumoh/oiyo/mydiaryback/domain/Travel.java
+++ b/my-diary-back/my-diary-back/src/main/java/kr/ac/kumoh/oiyo/mydiaryback/domain/Travel.java
@@ -1,5 +1,7 @@
 package kr.ac.kumoh.oiyo.mydiaryback.domain;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
 @Getter
 @NoArgsConstructor
 public class Travel extends BaseEntity {
@@ -20,7 +23,7 @@ public class Travel extends BaseEntity {
 
     // Member
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "MEMBER_ID")
+    @JoinColumn(name = "USER_ID")
     private User user;
 
     // Diary

--- a/my-diary-back/my-diary-back/src/main/java/kr/ac/kumoh/oiyo/mydiaryback/domain/User.java
+++ b/my-diary-back/my-diary-back/src/main/java/kr/ac/kumoh/oiyo/mydiaryback/domain/User.java
@@ -1,6 +1,8 @@
 package kr.ac.kumoh.oiyo.mydiaryback.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,12 +14,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
+@Table(name = "USER")
 @NoArgsConstructor
 @Getter
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "MEMBER_ID")
+    @Column(name = "USER_ID")
     private Long id;
 
     @Column


### PR DESCRIPTION
User를 만들고 만든 user에 travel을 생성해주었을 때 user를 조회하는 과정에서 무한 루프에 걸려 정상적으로 조회하지 못 하는 문제를 해결했습니다.